### PR TITLE
Fix RealOven GPIO handling without hardware

### DIFF
--- a/lib/oven.py
+++ b/lib/oven.py
@@ -48,12 +48,14 @@ class Output(object):
             self.active = False
 
     def heat(self,sleepfor):
-        self.GPIO.output(config.gpio_heat, self.GPIO.HIGH)
+        if self.active:
+            self.GPIO.output(config.gpio_heat, self.GPIO.HIGH)
         time.sleep(sleepfor)
 
     def cool(self,sleepfor):
         '''no active cooling, so sleep'''
-        self.GPIO.output(config.gpio_heat, self.GPIO.LOW)
+        if self.active:
+            self.GPIO.output(config.gpio_heat, self.GPIO.LOW)
         time.sleep(sleepfor)
 
 # FIX - Board class needs to be completely removed


### PR DESCRIPTION
## Summary
- avoid AttributeError when `RPi.GPIO` isn't available
- only drive GPIO pins when hardware is active

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b7d8ba7d08324ab956027dbabca96