### PR TITLE
Fix missing abort reference in websocket handler

### DIFF
--- a/kiln-controller.py
+++ b/kiln-controller.py
@@ -127,7 +127,7 @@ def get_websocket_from_request():
     env = bottle.request.environ
     wsock = env.get('wsgi.websocket')
     if not wsock:
-        abort(400, 'Expected WebSocket request.')
+        bottle.abort(400, 'Expected WebSocket request.')
     return wsock
 
 


### PR DESCRIPTION
## Summary
- fix crash when websocket request lacks wsgi.websocket

## Testing
- `python3 -m py_compile kiln-controller.py lib/oven.py kiln-logger.py watcher.py`

------
https://chatgpt.com/codex/tasks/task_e_685b7f5ee7648324a651f27f8683ac5a